### PR TITLE
Perform sentiment analysis when creating Media Reviews

### DIFF
--- a/app/controllers/admin/media_reviews_controller.rb
+++ b/app/controllers/admin/media_reviews_controller.rb
@@ -6,7 +6,7 @@ class Admin::MediaReviewsController < AdminController
 
   def create
     @event = find_event
-    @media_review = MediaReview.new(media_review_params)
+    @media_review = MediaReview::analyze_new(media_review_params, review_text)
 
     if @event.media_reviews << @media_review
       redirect_to @event
@@ -24,6 +24,10 @@ class Admin::MediaReviewsController < AdminController
   def media_review_params
     params.
       require(:media_review).
-      permit(:url)
+      permit(:url, :source, :headline, :author)
+  end
+
+  def review_text
+    params[:media_review_text]
   end
 end

--- a/app/controllers/admin/media_reviews_controller.rb
+++ b/app/controllers/admin/media_reviews_controller.rb
@@ -6,7 +6,10 @@ class Admin::MediaReviewsController < AdminController
 
   def create
     @event = find_event
-    @media_review = MediaReview.new_with_analysis(media_review_params, review_text)
+    @media_review = MediaReview.new_with_analysis(
+      media_review_params,
+      media_review_text
+    )
 
     if @event.media_reviews << @media_review
       redirect_to @event
@@ -27,7 +30,7 @@ class Admin::MediaReviewsController < AdminController
       permit(:url, :source, :headline, :author)
   end
 
-  def review_text
+  def media_review_text
     params[:media_review_text]
   end
 end

--- a/app/controllers/admin/media_reviews_controller.rb
+++ b/app/controllers/admin/media_reviews_controller.rb
@@ -6,7 +6,7 @@ class Admin::MediaReviewsController < AdminController
 
   def create
     @event = find_event
-    @media_review = MediaReview::analyze_new(media_review_params, review_text)
+    @media_review = MediaReview.new_with_analysis(media_review_params, review_text)
 
     if @event.media_reviews << @media_review
       redirect_to @event

--- a/app/models/media_review.rb
+++ b/app/models/media_review.rb
@@ -1,6 +1,8 @@
 class MediaReview < ActiveRecord::Base
   belongs_to :event
 
-  validates :url, presence: true
   validates :event, presence: true
+  validates :headline, presence: true
+  validates :source, presence: true
+  validates :url, presence: true
 end

--- a/app/models/media_review.rb
+++ b/app/models/media_review.rb
@@ -5,4 +5,19 @@ class MediaReview < ActiveRecord::Base
   validates :headline, presence: true
   validates :source, presence: true
   validates :url, presence: true
+
+  def self.analyze_new(review_params, review_text)
+    new(review_params.merge(sentiments_from(review_text)))
+  end
+
+  private
+
+  def self.sentiments_from(text)
+    analyzer = SentimentAnalyzer.new(text)
+    {
+      sentiment_positive: analyzer.positive,
+      sentiment_negative: analyzer.negative,
+      sentiment_neutral: analyzer.neutral
+    }
+  end
 end

--- a/app/models/media_review.rb
+++ b/app/models/media_review.rb
@@ -6,11 +6,9 @@ class MediaReview < ActiveRecord::Base
   validates :source, presence: true
   validates :url, presence: true
 
-  def self.analyze_new(review_params, review_text)
+  def self.new_with_analysis(review_params, review_text)
     new(review_params.merge(sentiments_from(review_text)))
   end
-
-  private
 
   def self.sentiments_from(text)
     analyzer = SentimentAnalyzer.new(text)
@@ -20,4 +18,5 @@ class MediaReview < ActiveRecord::Base
       sentiment_neutral: analyzer.neutral
     }
   end
+  private_class_method :sentiments_from
 end

--- a/app/models/sentiment_analyzer.rb
+++ b/app/models/sentiment_analyzer.rb
@@ -1,17 +1,30 @@
 class SentimentAnalyzer
+  BASE_URL = "http://text-processing.com/api"
+  ENDPOINT = "/sentiment/"
+  URL = BASE_URL + ENDPOINT
+
   def initialize(text)
-    @text = text
+    @post_params = { body: { text: URI::encode_www_form_component(text) } }
+    @query_result = perform_query
   end
 
   def positive
-    0.1
+    query_result["probability"]["pos"]
   end
 
   def negative
-    0.9
+    query_result["probability"]["neg"]
   end
 
   def neutral
-    0.675
+    query_result["probability"]["neutral"]
+  end
+
+  private
+
+  attr_reader :post_params, :query_result
+
+  def perform_query
+    HTTParty::post(URL, post_params)
   end
 end

--- a/app/models/sentiment_analyzer.rb
+++ b/app/models/sentiment_analyzer.rb
@@ -1,0 +1,17 @@
+class SentimentAnalyzer
+  def initialize(text)
+    @text = text
+  end
+
+  def positive
+    0.1
+  end
+
+  def negative
+    0.9
+  end
+
+  def neutral
+    0.675
+  end
+end

--- a/app/views/admin/media_reviews/new.html.erb
+++ b/app/views/admin/media_reviews/new.html.erb
@@ -10,6 +10,22 @@
     <%= form.text_field :url %>
   </div>
   <div>
+    <%= form.label :source %>
+    <%= form.text_field :source %>
+  </div>
+  <div>
+    <%= form.label :headline %>
+    <%= form.text_field :headline %>
+  </div>
+  <div>
+    <%= form.label :author %>
+    <%= form.text_field :author %>
+  </div>
+  <div>
+    <%= form.label :review_text %>
+    <%= text_area_tag :media_review_text %>
+  </div>
+  <div>
     <%= form.submit "Add Media Review" %>
   </div>
 <% end %>

--- a/app/views/media_reviews/_media_review.html.erb
+++ b/app/views/media_reviews/_media_review.html.erb
@@ -1,3 +1,8 @@
 <div class="media-review">
-  <%= link_to media_review.url, media_review.url %>
+  <%= media_review.source %>:
+  <%= link_to media_review.headline, media_review.url %>
+  (by <%= media_review.author %>)
+  [+<%= media_review.sentiment_positive %>,
+  -<%= media_review.sentiment_negative %>,
+  ~<%= media_review.sentiment_neutral %>]
 </div>

--- a/db/migrate/20140821171658_add_headline_author_source_to_media_reviews.rb
+++ b/db/migrate/20140821171658_add_headline_author_source_to_media_reviews.rb
@@ -1,0 +1,7 @@
+class AddHeadlineAuthorSourceToMediaReviews < ActiveRecord::Migration
+  def change
+    add_column :media_reviews, :headline, :string, null: false
+    add_column :media_reviews, :author, :string
+    add_column :media_reviews, :source, :string, null: false
+  end
+end

--- a/db/migrate/20140821174501_add_sentiments_to_media_reviews.rb
+++ b/db/migrate/20140821174501_add_sentiments_to_media_reviews.rb
@@ -1,0 +1,7 @@
+class AddSentimentsToMediaReviews < ActiveRecord::Migration
+  def change
+    add_column :media_reviews, :sentiment_positive, :float
+    add_column :media_reviews, :sentiment_negative, :float
+    add_column :media_reviews, :sentiment_neutral, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140820170639) do
+ActiveRecord::Schema.define(version: 20140821171658) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,9 @@ ActiveRecord::Schema.define(version: 20140820170639) do
     t.integer  "event_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "headline",   null: false
+    t.string   "author"
+    t.string   "source",     null: false
   end
 
   add_index "media_reviews", ["event_id"], name: "index_media_reviews_on_event_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140821171658) do
+ActiveRecord::Schema.define(version: 20140821174501) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,13 +28,16 @@ ActiveRecord::Schema.define(version: 20140821171658) do
   end
 
   create_table "media_reviews", force: true do |t|
-    t.string   "url",        null: false
+    t.string   "url",                null: false
     t.integer  "event_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "headline",   null: false
+    t.string   "headline",           null: false
     t.string   "author"
-    t.string   "source",     null: false
+    t.string   "source",             null: false
+    t.float    "sentiment_positive"
+    t.float    "sentiment_negative"
+    t.float    "sentiment_neutral"
   end
 
   add_index "media_reviews", ["event_id"], name: "index_media_reviews_on_event_id", using: :btree


### PR DESCRIPTION
- Add fields to `media_reviews`: `headline`, `author`, `source`, and 3 fields for sentiment
- Add presence validations for `headline` and `source` to model
- Add `source`, `headline`, `author`, and `review_text` fields to `media_reviews#new`
- Update `Admin::MediaReviewsController` with new fields
- Update `MediaReview` model with methods for sentiment analysis
- Create `SentimentAnalyzer` class with analysis methods via API
- Display (unfiltered) sentiment values in `_media_review` partial
