### PR TITLE
Fix event review counts

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,8 +20,8 @@ class Event < ActiveRecord::Base
 
   def self.with_review_statistics
     select("events.*").
-    select("COUNT(media_reviews.id) AS num_media_reviews").
-    select("COUNT(user_reviews.id) AS num_user_reviews").
+    select("COUNT(DISTINCT media_reviews.id) AS num_media_reviews").
+    select("COUNT(DISTINCT user_reviews.id) AS num_user_reviews").
     select("AVG(media_reviews.sentiment) AS average_media_review").
     select("AVG(user_reviews.rating) AS average_user_review").
     joins("LEFT JOIN media_reviews ON events.id = media_reviews.event_id").


### PR DESCRIPTION
Becuase we're outer joining across multiple tables, we need to use
`COUNT(DISTINCT ...)` instead of just `COUNT` for these statistics.
