### PR TITLE
Display "--" when no reviews and refactor review scores

### DIFF
--- a/app/assets/stylesheets/_review_scores.scss
+++ b/app/assets/stylesheets/_review_scores.scss
@@ -22,17 +22,17 @@ $review-score-default-color: transparentize($base-font-color, .4);
   float: left;
 }
 
-.review-score-positive {
+.review-score.positive {
   @extend .review-score;
   background-color: $review-score-positive-color;
 }
 
-.review-score-neutral {
+.review-score.neutral {
   @extend .review-score;
   background-color: $review-score-neutral-color;
 }
 
-.review-score-negative {
+.review-score.negative {
   @extend .review-score;
   background-color: $review-score-negative-color;
 }

--- a/app/helpers/reviews_helper.rb
+++ b/app/helpers/reviews_helper.rb
@@ -1,71 +1,24 @@
 module ReviewsHelper
-  def captioned_user_review_score_block(score, num_reviews)
-    converted_score = format_user_review_score(score)
-
-    content_tag :div, class: user_review_css_class(converted_score) do
-      review_score_caption("Users") +
-      converted_score +
+  def captioned_review_score_block(score, num_reviews, caption)
+    content_tag :div, class: review_score_css_class(score) do
+      review_score_caption(caption) +
+      score +
       num_reviews_caption(num_reviews)
     end
   end
 
-  def captioned_media_review_score_block(score, num_reviews)
-    converted_score = format_media_review_score(score)
-
-    content_tag :div, class: media_review_css_class(converted_score) do
-      review_score_caption("Critics") +
-      converted_score +
-      num_reviews_caption(num_reviews)
-    end
+  def review_score_block(score)
+    content_tag :div, score, class: review_score_css_class(score)
   end
 
-  def user_review_score_block(score)
-    converted_score = format_user_review_score(score)
-
-    content_tag :div, class: user_review_css_class(converted_score) do
-      converted_score
-    end
-  end
-
-  def media_review_score_block(score)
-    converted_score = format_media_review_score(score)
-
-    content_tag :div, class: media_review_css_class(converted_score) do
-      converted_score
-    end
-  end
-
-  def format_media_review_score(score)
-    # Convert score proportionally from (-1..1) to (0..100)
-    format_review_score(((score || -1) + 1) * 50)
-  end
-
-  def format_user_review_score(score)
-    format_review_score(score || 0)
+  def review_score_block(score)
+    content_tag :div, score, class: review_score_css_class(score)
   end
 
   private
 
-  def user_review_css_class(score)
-    case score.to_f
-    when 0.0...4.0 then "review-score-negative"
-    when 4.0...7.0 then "review-score-neutral"
-    when 7.0..10.0 then "review-score-positive"
-    else "review-score"
-    end
-  end
-
-  def media_review_css_class(score)
-    case score.to_f
-    when 0.0...40.0 then "review-score-negative"
-    when 40.0...60.0 then "review-score-neutral"
-    when 60.0..100.0 then "review-score-positive"
-    else "review-score"
-    end
-  end
-
-  def format_review_score(score)
-    number_with_precision(score, precision: 1, strip_insignificant_zeros: true)
+  def review_score_css_class(score)
+    "review-score #{score.category}"
   end
 
   def num_reviews_caption(num_reviews)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,4 +32,12 @@ class Event < ActiveRecord::Base
   def nyt_date_older_than?(date)
     nyt_updated_at < date
   end
+
+  def average_user_review_score
+    @average_user_review_score ||= UserReviewScore.new(average_user_review)
+  end
+
+  def average_media_review_score
+    @average_media_review_score ||= MediaReviewScore.new(average_media_review)
+  end
 end

--- a/app/models/media_review.rb
+++ b/app/models/media_review.rb
@@ -5,4 +5,8 @@ class MediaReview < ActiveRecord::Base
   validates :headline, presence: true
   validates :source, presence: true
   validates :url, presence: true
+
+  def score
+    @score ||= MediaReviewScore.new(rating)
+  end
 end

--- a/app/models/media_review.rb
+++ b/app/models/media_review.rb
@@ -7,6 +7,6 @@ class MediaReview < ActiveRecord::Base
   validates :url, presence: true
 
   def score
-    @score ||= MediaReviewScore.new(rating)
+    @score ||= MediaReviewScore.new(sentiment)
   end
 end

--- a/app/models/media_review_score.rb
+++ b/app/models/media_review_score.rb
@@ -1,13 +1,14 @@
-class MediaReviewScore
+class MediaReviewScore < ReviewScore
   def initialize(media_review_value)
-    @media_review_value = media_review_value
+    @score = ((media_review_value || -1) + 1) * 50
   end
 
-  def to_s
-    number_with_precision(media_review_value, precision: 1, strip_insignificant_zeros: true)
+  def category
+    case score
+    when 0.0 then nil
+    when 0.0...40.0 then :negative
+    when 40.0...60.0 then :neutral
+    when 60.0..100.0 then :positive
+    end
   end
-
-  private
-
-  attr_reader :media_review_value
 end

--- a/app/models/media_review_score.rb
+++ b/app/models/media_review_score.rb
@@ -1,0 +1,13 @@
+class MediaReviewScore
+  def initialize(media_review_value)
+    @media_review_value = media_review_value
+  end
+
+  def to_s
+    number_with_precision(media_review_value, precision: 1, strip_insignificant_zeros: true)
+  end
+
+  private
+
+  attr_reader :media_review_value
+end

--- a/app/models/media_review_score.rb
+++ b/app/models/media_review_score.rb
@@ -5,10 +5,11 @@ class MediaReviewScore < ReviewScore
 
   def category
     case score
-    when 0.0 then nil
+    when 0.0 then :""
     when 0.0...40.0 then :negative
     when 40.0...60.0 then :neutral
     when 60.0..100.0 then :positive
+    else :""
     end
   end
 end

--- a/app/models/review_score.rb
+++ b/app/models/review_score.rb
@@ -1,0 +1,21 @@
+class ReviewScore
+  def to_s
+    if score == 0
+      "--"
+    else
+      format_score.to_s
+    end
+  end
+
+  private
+
+  attr_reader :score
+
+  def format_score
+    if score.integer?
+      score.round(0)
+    else
+      score.round(1)
+    end
+  end
+end

--- a/app/models/user_review.rb
+++ b/app/models/user_review.rb
@@ -8,7 +8,7 @@ class UserReview < ActiveRecord::Base
     presence: true,
     numericality: {
       only_integer: true,
-      greater_than_or_equal_to: 0,
+      greater_than_or_equal_to: 1,
       less_than_or_equal_to: 10
     }
   validates :user,

--- a/app/models/user_review.rb
+++ b/app/models/user_review.rb
@@ -17,4 +17,8 @@ class UserReview < ActiveRecord::Base
       scope: :event,
       message: "can only review an event once"
     }
+
+  def score
+    @score ||= UserReviewScore.new(rating)
+  end
 end

--- a/app/models/user_review_score.rb
+++ b/app/models/user_review_score.rb
@@ -1,0 +1,13 @@
+class UserReviewScore
+  def initialize(user_review_value)
+    @user_review_value = user_review_value
+  end
+
+  def to_s
+    number_with_precision(user_review_value, precision: 1, strip_insignificant_zeros: true)
+  end
+
+  private
+
+  attr_reader :user_review_value
+end

--- a/app/models/user_review_score.rb
+++ b/app/models/user_review_score.rb
@@ -1,13 +1,14 @@
-class UserReviewScore
+class UserReviewScore < ReviewScore
   def initialize(user_review_value)
-    @user_review_value = user_review_value
+    @score = user_review_value || 0
   end
 
-  def to_s
-    number_with_precision(user_review_value, precision: 1, strip_insignificant_zeros: true)
+  def category
+    case score
+    when 0 then nil
+    when 0.0...4.0 then :negative
+    when 4.0...7.0 then :neutral
+    when 7.0..10.0 then :positive
+    end
   end
-
-  private
-
-  attr_reader :user_review_value
 end

--- a/app/models/user_review_score.rb
+++ b/app/models/user_review_score.rb
@@ -5,10 +5,11 @@ class UserReviewScore < ReviewScore
 
   def category
     case score
-    when 0 then nil
+    when 0 then :""
     when 0.0...4.0 then :negative
     when 4.0...7.0 then :neutral
     when 7.0..10.0 then :positive
+    else :""
     end
   end
 end

--- a/app/views/events/_event_statistics.html.erb
+++ b/app/views/events/_event_statistics.html.erb
@@ -1,5 +1,5 @@
 <div class="event-statistics">
-  <%= captioned_user_review_score_block(event.average_user_review, event.num_user_reviews) %>
+  <%= captioned_review_score_block(event.average_user_review_score, event.num_user_reviews, "Users") %>
 
-  <%= captioned_media_review_score_block(event.average_media_review, event.num_media_reviews) %>
+  <%= captioned_review_score_block(event.average_media_review_score, event.num_media_reviews, "Critics") %>
 </div>

--- a/app/views/media_reviews/_media_review.html.erb
+++ b/app/views/media_reviews/_media_review.html.erb
@@ -1,5 +1,5 @@
 <div class="review">
-  <%= media_review_score_block(media_review.sentiment) %>
+  <%= review_score_block(media_review.score) %>
 
   <div class="review-content">
     <h4><%= link_to media_review.headline, media_review.url %></h4>

--- a/app/views/user_reviews/_user_review.html.erb
+++ b/app/views/user_reviews/_user_review.html.erb
@@ -1,5 +1,5 @@
 <div class="review user-review">
-  <%= user_review_score_block(user_review.rating) %>
+  <%= review_score_block(user_review.score) %>
 
   <div class="review-content">
     <h4>Review by <%= format_user_name(user_review.user) %></h4>

--- a/app/views/user_reviews/_user_review_form.html.erb
+++ b/app/views/user_reviews/_user_review_form.html.erb
@@ -2,7 +2,7 @@
 
 <div>
   <%= form.label :rating %>
-  <%= form.select :rating, options_for_select(0..10, form.object.rating) %>
+  <%= form.select :rating, options_for_select(1..10, form.object.rating) %>
 </div>
 <div>
   <%= form.label :body %>


### PR DESCRIPTION
**Display "--" instead of "0" when there are no reviews:**
- Disallow 0 scores for User Reviews
- Display gray box with '--' for no reviews

**Refactor review scores using value objects:**
- Extract parent class for a generic review score
- Extract classes for media and user review scores
- Add helper methods to `UserReview`, `MediaReview` and `Event`
- Heavily refactor reviews helper to use review scores
- Update views to use refactored helper methods
- Slightly refactor CSS for review scores

https://trello.com/c/UoofkvMS

http://blog.codeclimate.com/blog/2012/10/17/7-ways-to-decompose-fat-activerecord-models/#value-objects
