### PR TITLE
Add dashboard for events with top critic reviews + refactor

### DIFF
--- a/app/controllers/closed_events_dashboard_controller.rb
+++ b/app/controllers/closed_events_dashboard_controller.rb
@@ -2,6 +2,6 @@ class ClosedEventsDashboardController < ApplicationController
   skip_before_action :require_login, only: [:show]
 
   def show
-    @events = Event.closed.with_review_statistics
+    @events = Event.closed
   end
 end

--- a/app/controllers/current_events_dashboard_controller.rb
+++ b/app/controllers/current_events_dashboard_controller.rb
@@ -2,6 +2,6 @@ class CurrentEventsDashboardController < ApplicationController
   skip_before_action :require_login, only: [:show]
 
   def show
-    @events = Event.current.with_review_statistics
+    @events = Event.current
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,7 +3,6 @@ class EventsController < ApplicationController
 
   def show
     @event = Event.
-      with_review_statistics.
       includes(user_reviews: :user).
       find(params[:id])
   end

--- a/app/controllers/search_results_controller.rb
+++ b/app/controllers/search_results_controller.rb
@@ -3,6 +3,6 @@ class SearchResultsController < ApplicationController
 
   def show
     @search_query = params[:event_name]
-    @search_results = Event.current.search(@search_query).with_review_statistics
+    @search_results = Event.current.search(@search_query)
   end
 end

--- a/app/controllers/top_media_events_dashboard_controller.rb
+++ b/app/controllers/top_media_events_dashboard_controller.rb
@@ -2,6 +2,6 @@ class TopMediaEventsDashboardController < ApplicationController
   skip_before_action :require_login, only: [:show]
 
   def show
-    @events = Event.current.with_review_statistics_by_average_media_review
+    @events = Event.current.by_average_media_review
   end
 end

--- a/app/controllers/top_media_events_dashboard_controller.rb
+++ b/app/controllers/top_media_events_dashboard_controller.rb
@@ -1,0 +1,7 @@
+class TopMediaEventsDashboardController < ApplicationController
+  skip_before_action :require_login, only: [:show]
+
+  def show
+    @events = Event.current.with_review_statistics_by_average_media_review
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -25,11 +25,7 @@ class Event < ActiveRecord::Base
     where("name ILIKE ?", "%#{event_name}%")
   end
 
-  def self.with_review_statistics
-    all
-  end
-
-  def self.with_review_statistics_by_average_media_review
+  def self.by_average_media_review
     joins(:review_statistics_summary).
     where("average_media_review IS NOT NULL").
     order("average_media_review DESC")

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,7 +7,9 @@ class Event < ActiveRecord::Base
   validates :name, presence: true
   validates :nyt_event_id, uniqueness: true, allow_blank: true
 
-  delegate :average_user_review, :average_media_review, to: :review_statistics_summary
+  delegate :average_user_review,
+    :average_media_review,
+    to: :review_statistics_summary
 
   def self.default_scope
     includes(:review_statistics_summary)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -29,6 +29,12 @@ class Event < ActiveRecord::Base
     group("events.id")
   end
 
+  def self.with_review_statistics_by_average_media_review
+    with_review_statistics.
+    having("AVG(media_reviews.sentiment) IS NOT NULL").
+    order("average_media_review DESC")
+  end
+
   def nyt_date_older_than?(date)
     nyt_updated_at < date
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,8 +20,6 @@ class Event < ActiveRecord::Base
 
   def self.with_review_statistics
     select("events.*").
-    select("COUNT(DISTINCT media_reviews.id) AS num_media_reviews").
-    select("COUNT(DISTINCT user_reviews.id) AS num_user_reviews").
     select("AVG(media_reviews.sentiment) AS average_media_review").
     select("AVG(user_reviews.rating) AS average_user_review").
     joins("LEFT JOIN media_reviews ON events.id = media_reviews.event_id").

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,11 +9,11 @@ class Event < ActiveRecord::Base
 
   delegate :average_user_review,
     :average_media_review,
+    :average_user_review_score,
+    :average_media_review_score,
     to: :review_statistics_summary
 
-  def self.default_scope
-    includes(:review_statistics_summary)
-  end
+  default_scope { includes(:review_statistics_summary) }
 
   def self.current
     where("closing_date IS NULL OR closing_date >= ?", Date.today)
@@ -35,13 +35,5 @@ class Event < ActiveRecord::Base
 
   def nyt_date_older_than?(date)
     nyt_updated_at < date
-  end
-
-  def average_user_review_score
-    @average_user_review_score ||= UserReviewScore.new(average_user_review)
-  end
-
-  def average_media_review_score
-    @average_media_review_score ||= MediaReviewScore.new(average_media_review)
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,9 +2,16 @@ class Event < ActiveRecord::Base
   has_many :event_preferences
   has_many :user_reviews, dependent: :destroy
   has_many :media_reviews, dependent: :destroy
+  has_one :review_statistics_summary, foreign_key: :event_id
 
   validates :name, presence: true
   validates :nyt_event_id, uniqueness: true, allow_blank: true
+
+  delegate :average_user_review, :average_media_review, to: :review_statistics_summary
+
+  def self.default_scope
+    includes(:review_statistics_summary)
+  end
 
   def self.current
     where("closing_date IS NULL OR closing_date >= ?", Date.today)
@@ -19,17 +26,12 @@ class Event < ActiveRecord::Base
   end
 
   def self.with_review_statistics
-    select("events.*").
-    select("AVG(media_reviews.sentiment) AS average_media_review").
-    select("AVG(user_reviews.rating) AS average_user_review").
-    joins("LEFT JOIN media_reviews ON events.id = media_reviews.event_id").
-    joins("LEFT JOIN user_reviews ON events.id = user_reviews.event_id").
-    group("events.id")
+    all
   end
 
   def self.with_review_statistics_by_average_media_review
-    with_review_statistics.
-    having("AVG(media_reviews.sentiment) IS NOT NULL").
+    joins(:review_statistics_summary).
+    where("average_media_review IS NOT NULL").
     order("average_media_review DESC")
   end
 

--- a/app/models/media_review.rb
+++ b/app/models/media_review.rb
@@ -1,5 +1,5 @@
 class MediaReview < ActiveRecord::Base
-  belongs_to :event
+  belongs_to :event, counter_cache: :num_media_reviews
 
   validates :event, presence: true
   validates :headline, presence: true

--- a/app/models/review_statistics_summary.rb
+++ b/app/models/review_statistics_summary.rb
@@ -3,4 +3,12 @@ class ReviewStatisticsSummary < ActiveRecord::Base
   self.primary_key = "event_id"
 
   belongs_to :event
+
+  def average_user_review_score
+    @average_user_review_score ||= UserReviewScore.new(average_user_review)
+  end
+
+  def average_media_review_score
+    @average_media_review_score ||= MediaReviewScore.new(average_media_review)
+  end
 end

--- a/app/models/review_statistics_summary.rb
+++ b/app/models/review_statistics_summary.rb
@@ -1,0 +1,6 @@
+class ReviewStatisticsSummary < ActiveRecord::Base
+  self.table_name = "event_review_statistics"
+  self.primary_key = "event_id"
+
+  belongs_to :event
+end

--- a/app/models/user_review.rb
+++ b/app/models/user_review.rb
@@ -1,6 +1,6 @@
 class UserReview < ActiveRecord::Base
   belongs_to :user
-  belongs_to :event
+  belongs_to :event, counter_cache: :num_user_reviews
 
   validates :body, presence: true
   validates :event, presence: true

--- a/app/views/application/_navigation.html.erb
+++ b/app/views/application/_navigation.html.erb
@@ -8,6 +8,7 @@
       <ul id="navigation-menu">
         <li class="nav-link"><%= link_to "Current Events", current_events_path %></li>
         <li class="nav-link"><%= link_to "Recently Closed", closed_events_path %></li>
+        <li class="nav-link"><%= link_to "Critics Recommend", top_critic_events_path %></li>
         <% if current_user.admin? %>
           <li class="nav-link"><%= link_to "Admin Dashboard", admin_dashboard_path %></li>
         <% end %>

--- a/app/views/top_media_events_dashboard/show.html.erb
+++ b/app/views/top_media_events_dashboard/show.html.erb
@@ -1,0 +1,5 @@
+<div class="events">
+  <h2>Critics Recommend</h2>
+
+  <%= render @events %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
     collection do
       get "current" => "current_events_dashboard#show"
       get "closed" => "closed_events_dashboard#show"
+      get "top_critic" => "top_media_events_dashboard#show"
     end
   end
 

--- a/db/migrate/20140904191344_add_counter_cache_columns_to_events.rb
+++ b/db/migrate/20140904191344_add_counter_cache_columns_to_events.rb
@@ -1,0 +1,17 @@
+class AddCounterCacheColumnsToEvents < ActiveRecord::Migration
+  class Event < ActiveRecord::Base
+    has_many :user_reviews
+    has_many :media_reviews
+  end
+
+  def change
+    add_column :events, :num_user_reviews, :integer, default: 0
+    add_column :events, :num_media_reviews, :integer, default: 0
+
+    Event.all.each do |event|
+      event.num_user_reviews = event.user_reviews.count
+      event.num_media_reviews = event.media_reviews.count
+      event.save!
+    end
+  end
+end

--- a/db/migrate/20140905143607_create_event_review_statistics_view.rb
+++ b/db/migrate/20140905143607_create_event_review_statistics_view.rb
@@ -1,0 +1,21 @@
+class CreateEventReviewStatisticsView < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      CREATE VIEW event_review_statistics AS
+        SELECT
+          events.id as event_id,
+          AVG(user_reviews.rating) AS average_user_review,
+          AVG(media_reviews.sentiment) AS average_media_review
+        FROM
+          events
+          LEFT JOIN user_reviews ON events.id = user_reviews.event_id
+          LEFT JOIN media_reviews ON events.id = media_reviews.event_id
+        GROUP BY
+          events.id
+    SQL
+  end
+
+  def down
+    execute "DROP VIEW event_review_statistics"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140904191344) do
+ActiveRecord::Schema.define(version: 20140905143607) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140829175123) do
+ActiveRecord::Schema.define(version: 20140904191344) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 20140829175123) do
   add_index "event_preferences", ["user_id"], name: "index_event_preferences_on_user_id", using: :btree
 
   create_table "events", force: true do |t|
-    t.string   "name",           null: false
+    t.string   "name",                          null: false
     t.string   "venue"
     t.text     "description"
     t.date     "closing_date"
@@ -36,6 +36,8 @@ ActiveRecord::Schema.define(version: 20140829175123) do
     t.datetime "updated_at"
     t.integer  "nyt_event_id"
     t.datetime "nyt_updated_at"
+    t.integer  "num_user_reviews",  default: 0
+    t.integer  "num_media_reviews", default: 0
   end
 
   create_table "media_reviews", force: true do |t|


### PR DESCRIPTION
**Add dashboard for events with top critic reviews:**
- Add route, controller, and view for top media events dashboard
- Add method to `Event` for events with highest media review scores
- Add link to application layout

**Refactor: Add counter cache for user and media review counts:**
- Create migration to add columns to `events`, setting current value from data
- Refactor `with_review_statistics` method to remove unnecessary `COUNT`

**Refactor: Use DB view to compute review statistics:**
- Add migration to create view with user and media review averages
- Create `ReviewStatisticsSummary` AR model for view
- Add relationship to `Event` for `ReviewStatisticsSummary`
- Delegate average methods from `Event` to `ReviewStatisticsSummary`
- Add `default_scope` to `Event` to always eager load statistics
- Remove `with_review_statistics` method from `Event` (and controllers)
