### PR TITLE
Set default sort orders for events and reviews

### DIFF
--- a/app/controllers/closed_events_dashboard_controller.rb
+++ b/app/controllers/closed_events_dashboard_controller.rb
@@ -2,6 +2,6 @@ class ClosedEventsDashboardController < ApplicationController
   skip_before_action :require_login, only: [:show]
 
   def show
-    @events = Event.closed
+    @events = Event.closed.by_closing_date
   end
 end

--- a/app/controllers/current_events_dashboard_controller.rb
+++ b/app/controllers/current_events_dashboard_controller.rb
@@ -2,6 +2,6 @@ class CurrentEventsDashboardController < ApplicationController
   skip_before_action :require_login, only: [:show]
 
   def show
-    @events = Event.current
+    @events = Event.current.by_name
   end
 end

--- a/app/controllers/search_results_controller.rb
+++ b/app/controllers/search_results_controller.rb
@@ -3,6 +3,6 @@ class SearchResultsController < ApplicationController
 
   def show
     @search_query = params[:event_name]
-    @search_results = Event.current.search(@search_query)
+    @search_results = Event.current.search(@search_query).by_name
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -27,16 +27,24 @@ class Event < ActiveRecord::Base
     where("name ILIKE ?", "%#{event_name}%")
   end
 
+  def self.by_name
+    order(name: :asc)
+  end
+
+  def self.by_closing_date
+    order(closing_date: :desc, name: :asc)
+  end
+
   def self.by_average_media_review
     joins(:review_statistics_summary).
     where("average_media_review IS NOT NULL").
-    order("average_media_review DESC")
+    order("average_media_review DESC, name ASC")
   end
 
   def self.by_average_user_review
     joins(:review_statistics_summary).
     where("average_user_review IS NOT NULL").
-    order("average_user_review DESC")
+    order("average_user_review DESC, name ASC")
   end
 
   def nyt_date_older_than?(date)

--- a/app/models/media_review.rb
+++ b/app/models/media_review.rb
@@ -6,6 +6,8 @@ class MediaReview < ActiveRecord::Base
   validates :source, presence: true
   validates :url, presence: true
 
+  default_scope { order(created_at: :desc) }
+
   def score
     @score ||= MediaReviewScore.new(sentiment)
   end

--- a/app/models/user_review.rb
+++ b/app/models/user_review.rb
@@ -18,6 +18,8 @@ class UserReview < ActiveRecord::Base
       message: "can only review an event once"
     }
 
+  default_scope { order(created_at: :desc) }
+
   def score
     @score ||= UserReviewScore.new(rating)
   end


### PR DESCRIPTION
- Add `by_name` and `by_closing_date` helpers to `Event`
- Sort events on current event dashboard by name
- Sort events on closed event dashboard by closing date (reverse)
- Sort events in search results by name
- Sort user and media reviews in reverse chronological order

https://trello.com/c/AhJvAq5A
