### PR TITLE
Users can edit user reviews they posted

### DIFF
--- a/app/controllers/admin/user_reviews_controller.rb
+++ b/app/controllers/admin/user_reviews_controller.rb
@@ -1,4 +1,4 @@
-class Admin::UserReviewsController < ApplicationController
+class Admin::UserReviewsController < AdminController
   def edit
     @user_review = find_user_review
   end

--- a/app/controllers/user_reviews_controller.rb
+++ b/app/controllers/user_reviews_controller.rb
@@ -1,4 +1,6 @@
 class UserReviewsController < ApplicationController
+  before_action :require_ownership, only: [:edit, :update]
+
   def new
     @event = find_event
     @user_review = UserReview.new
@@ -6,7 +8,7 @@ class UserReviewsController < ApplicationController
 
   def create
     @event = find_event
-    @user_review = UserReview.new(user_review_params)
+    @user_review = UserReview.new(user_review_params_with_event)
 
     if current_user.user_reviews << @user_review
       redirect_to @event
@@ -15,16 +17,42 @@ class UserReviewsController < ApplicationController
     end
   end
 
+  def edit
+    @user_review = find_user_review
+  end
+
+  def update
+    @user_review = find_user_review
+
+    if @user_review.update(user_review_params)
+      redirect_to @user_review.event
+    else
+      render :edit
+    end
+  end
+
   private
+
+  def require_ownership
+    unless find_user_review.created_by?(current_user)
+      flash[:alert] = "You are not authorized to view that page."
+      redirect_to find_user_review.event
+    end
+  end
 
   def find_event
     Event.find(params[:event_id])
   end
 
+  def find_user_review
+    @user_review ||= UserReview.find(params[:id])
+  end
+
   def user_review_params
-    params.
-      require(:user_review).
-      permit(:body, :rating).
-      merge(event_id: @event.id)
+    params.require(:user_review).permit(:body, :rating)
+  end
+
+  def user_review_params_with_event
+    user_review_params.merge(event_id: @event.id)
   end
 end

--- a/app/controllers/user_reviews_controller.rb
+++ b/app/controllers/user_reviews_controller.rb
@@ -41,7 +41,7 @@ class UserReviewsController < ApplicationController
   end
 
   def find_event
-    Event.find(params[:event_id])
+    @event ||= Event.find(params[:event_id])
   end
 
   def find_user_review
@@ -53,6 +53,6 @@ class UserReviewsController < ApplicationController
   end
 
   def user_review_params_with_event
-    user_review_params.merge(event_id: @event.id)
+    user_review_params.merge(event_id: find_event.id)
   end
 end

--- a/app/helpers/reviews_helper.rb
+++ b/app/helpers/reviews_helper.rb
@@ -11,8 +11,14 @@ module ReviewsHelper
     content_tag :div, score, class: review_score_css_class(score)
   end
 
-  def review_score_block(score)
-    content_tag :div, score, class: review_score_css_class(score)
+  def review_modify_links_for(user_review)
+    content_tag :div, class: "review-modify-links" do
+      if current_user.admin?
+        admin_modify_links_for(user_review)
+      elsif user_review.created_by?(current_user)
+        creator_modify_links_for(user_review)
+      end
+    end
   end
 
   private
@@ -27,5 +33,19 @@ module ReviewsHelper
 
   def review_score_caption(text)
     content_tag(:div, text, class: "review-score-caption")
+  end
+
+  def admin_modify_links_for(user_review)
+    link_to("Edit", edit_admin_user_review_path(user_review)) +
+    link_to(
+      "Delete",
+      admin_user_review_path(user_review),
+      method: :delete,
+      data: { confirm: "Are you sure?" }
+    )
+  end
+
+  def creator_modify_links_for(user_review)
+    link_to "Edit", edit_user_review_path(user_review)
   end
 end

--- a/app/helpers/reviews_helper.rb
+++ b/app/helpers/reviews_helper.rb
@@ -11,12 +11,12 @@ module ReviewsHelper
     content_tag :div, score, class: review_score_css_class(score)
   end
 
-  def review_modify_links_for(user_review)
+  def edit_links_for(user_review)
     content_tag :div, class: "review-modify-links" do
       if current_user.admin?
-        admin_modify_links_for(user_review)
+        admin_edit_links_for(user_review)
       elsif user_review.created_by?(current_user)
-        creator_modify_links_for(user_review)
+        creator_edit_links_for(user_review)
       end
     end
   end
@@ -35,7 +35,7 @@ module ReviewsHelper
     content_tag(:div, text, class: "review-score-caption")
   end
 
-  def admin_modify_links_for(user_review)
+  def admin_edit_links_for(user_review)
     link_to("Edit", edit_admin_user_review_path(user_review)) +
     link_to(
       "Delete",
@@ -45,7 +45,7 @@ module ReviewsHelper
     )
   end
 
-  def creator_modify_links_for(user_review)
+  def creator_edit_links_for(user_review)
     link_to "Edit", edit_user_review_path(user_review)
   end
 end

--- a/app/models/Guest.rb
+++ b/app/models/Guest.rb
@@ -1,4 +1,8 @@
 class Guest
+  def id
+    nil
+  end
+
   def admin?
     false
   end

--- a/app/models/user_review.rb
+++ b/app/models/user_review.rb
@@ -23,4 +23,8 @@ class UserReview < ActiveRecord::Base
   def score
     @score ||= UserReviewScore.new(rating)
   end
+
+  def created_by?(user)
+    user_id == user.id
+  end
 end

--- a/app/views/user_reviews/_user_review.html.erb
+++ b/app/views/user_reviews/_user_review.html.erb
@@ -8,11 +8,6 @@
 
     <p class="review-detail">Reviewed <%= time_ago_in_words user_review.created_at %> ago.</p>
 
-    <% if current_user.admin? %>
-      <div class="review-modify-links">
-        <%= link_to "Edit", edit_admin_user_review_path(user_review) %>
-        <%= link_to "Delete", admin_user_review_path(user_review), method: :delete, data: { confirm: "Are you sure?" } %>
-      </div>
-    <% end %>
+    <%= review_modify_links_for(user_review) %>
   </div>
 </div>

--- a/app/views/user_reviews/_user_review.html.erb
+++ b/app/views/user_reviews/_user_review.html.erb
@@ -8,6 +8,6 @@
 
     <p class="review-detail">Reviewed <%= time_ago_in_words user_review.created_at %> ago.</p>
 
-    <%= review_modify_links_for(user_review) %>
+    <%= edit_links_for(user_review) %>
   </div>
 </div>

--- a/app/views/user_reviews/edit.html.erb
+++ b/app/views/user_reviews/edit.html.erb
@@ -2,8 +2,8 @@
 
 <h3>Edit a Review</h3>
 
-<%= form_for [:admin, @user_review] do |form| %>
-  <%= render "user_reviews/user_review_form", form: form %>
+<%= form_for @user_review do |form| %>
+  <%= render "user_review_form", form: form %>
 
   <div>
     <%= form.submit "Update Review" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,8 @@ Rails.application.routes.draw do
 
   root "current_events_dashboard#show"
 
-  resources :events, only: [:show] do
-    resources :user_reviews, only: [:new, :create]
+  resources :events, only: [:show], shallow: true do
+    resources :user_reviews, only: [:new, :create, :edit, :update]
     resources :event_preferences, only: [:create], as: :preferences
 
     collection do

--- a/spec/controllers/user_reviews_controller_spec.rb
+++ b/spec/controllers/user_reviews_controller_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe UserReviewsController do
+  before do
+    @user_review = create(:user_review, user: create(:user))
+    sign_in(create(:user))
+  end
+
+  describe "#edit" do
+    it "redirects a user who did not create the user review with that id" do
+      get :edit, id: @user_review.id
+
+      expect_redirect_to_event
+      expect_flash_with_not_authorized_message
+    end
+  end
+
+  describe "#update" do
+    it "redirects a user who did not create the user review with that id" do
+      put(:update, id: @user_review.id, user_review: @user_review.attributes)
+
+      expect_redirect_to_event
+      expect_flash_with_not_authorized_message
+    end
+  end
+
+  def expect_redirect_to_event
+    expect(response).to redirect_to(@user_review.event)
+  end
+
+  def expect_flash_with_not_authorized_message
+    expect(flash[:alert]).to match(/not authorized/)
+  end
+end

--- a/spec/features/user_edits_user_review_spec.rb
+++ b/spec/features/user_edits_user_review_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+feature "User can edit a user review from an event page" do
+  before do
+    @event = create(:event)
+    @user = create(:user)
+  end
+
+  scenario "User edits their own review for an event" do
+    user_review = create(:user_review, event: @event, user: @user)
+    new_rating = user_review.rating - 1
+    new_body = "Changed review text."
+
+    visit_event_as_user
+    find(".user-review").click_link("Edit")
+    select(new_rating, from: "Rating")
+    fill_in "Body", with: new_body
+    click_button "Update Review"
+
+    expect_user_review_score_to_update_from(user_review.score, new_rating)
+    expect_user_review_body_to_update_from(user_review.body, new_body)
+  end
+
+  scenario "User does not see edit option for reviews they did not create" do
+    other_user = create(:user)
+    user_review = create(:user_review, event: @event, user: other_user)
+
+    visit_event_as_user
+
+    expect(page).to have_content(user_review.body)
+    expect(page).not_to have_css(".user-review", text: "Edit")
+  end
+
+  def visit_event_as_user
+    visit event_path(@event, as: @user)
+  end
+
+  def expect_user_review_score_to_update_from(old_value, new_value)
+    expect(page).not_to have_user_review_score(old_value)
+    expect(page).to have_user_review_score(new_value)
+  end
+
+  def expect_user_review_body_to_update_from(old_value, new_value)
+    expect(page).not_to have_user_review_body(old_value)
+    expect(page).to have_user_review_body(new_value)
+  end
+
+  def have_user_review_score(score)
+    have_css(".user-review .review-score", text: score)
+  end
+
+  def have_user_review_body(text)
+    have_css(".user-review .review-content", text: text)
+  end
+end

--- a/spec/features/user_edits_user_review_spec.rb
+++ b/spec/features/user_edits_user_review_spec.rb
@@ -11,7 +11,7 @@ feature "User can edit a user review from an event page" do
     new_rating = user_review.rating - 1
     new_body = "Changed review text."
 
-    visit_event_as_user
+    visit_event
     find(".user-review").click_link("Edit")
     select(new_rating, from: "Rating")
     fill_in "Body", with: new_body
@@ -25,13 +25,13 @@ feature "User can edit a user review from an event page" do
     other_user = create(:user)
     user_review = create(:user_review, event: @event, user: other_user)
 
-    visit_event_as_user
+    visit_event
 
     expect(page).to have_content(user_review.body)
     expect(page).not_to have_css(".user-review", text: "Edit")
   end
 
-  def visit_event_as_user
+  def visit_event
     visit event_path(@event, as: @user)
   end
 

--- a/spec/models/guest_spec.rb
+++ b/spec/models/guest_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+describe Guest do
+  describe "#id" do
+    it "returns nil" do
+      expect(Guest.new.id).to be nil
+    end
+  end
+
+  describe "#admin?" do
+    it "returns false" do
+      expect(Guest.new.admin?).to be false
+    end
+  end
+
+  describe "#can_review?" do
+    it "returns false" do
+      event = build(:event)
+      guest = Guest.new
+
+      expect(guest.can_review?(event)).to be false
+    end
+  end
+end

--- a/spec/models/user_review_spec.rb
+++ b/spec/models/user_review_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+describe UserReview do
+  describe "#created_by?" do
+    context "when the given user created the user review" do
+      it "returns true" do
+        user = create(:user)
+        user_review = create(:user_review, user: user)
+
+        expect(user_review.created_by?(user)).to be true
+      end
+    end
+
+    context "when the given user did not create the user review" do
+      it "returns false" do
+        user = create(:user)
+        another_user = create(:user)
+        user_review = create(:user_review, user: another_user)
+
+        expect(user_review.created_by?(user)).to be false
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,7 +18,7 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 
   config.include Monban::Test::ControllerHelpers, type: :controller
-  config.after :each do
+  config.after do
     Monban.test_reset!
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,4 +16,9 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   config.include FactoryGirl::Syntax::Methods
+
+  config.include Monban::Test::ControllerHelpers, type: :controller
+  config.after :each do
+    Monban.test_reset!
+  end
 end


### PR DESCRIPTION
- Extract helper method for displaying modify links for a user review
- Don't show the "Edit" link for reviews created by other users
- Add feature specs for a user editing their own user reviews
- Add unit and controller specs relevant to this PR

Additionally, correct the parent controller class for `Admin::UserReviewsController` so that only admins can access these actions.

https://trello.com/c/CLwkMCBI
