### PR TITLE
Add feature specs for current events dashboard

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -9,8 +9,16 @@ FactoryGirl.define do
     venue "Majestic Theatre"
     without_closing_date
 
-    factory :event_with_media_reviews do
-      ignore { media_review_count 2 }
+    trait :closed do
+      closing_date { 1.day.ago }
+    end
+
+    trait :open do
+      closing_date { 1.day.from_now }
+    end
+
+    trait :with_media_reviews do
+      ignore { media_review_count 3 }
 
       after :create do |instance, evaluator|
         create_list(
@@ -21,7 +29,12 @@ FactoryGirl.define do
       end
     end
 
-    factory :event_with_user_reviews do
+    trait :with_reviews do
+      with_user_reviews
+      with_media_reviews
+    end
+
+    trait :with_user_reviews do
       ignore { user_review_count 2 }
 
       after :create do |instance, evaluator|
@@ -31,14 +44,6 @@ FactoryGirl.define do
           event: instance
         )
       end
-    end
-
-    trait :closed do
-      closing_date { 1.day.ago }
-    end
-
-    trait :open do
-      closing_date { 1.day.from_now }
     end
 
     trait :without_closing_date do

--- a/spec/features/admin_manages_user_review_spec.rb
+++ b/spec/features/admin_manages_user_review_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 feature "Admin manages a user review for an event" do
   before do
-    @event = create(:event_with_user_reviews, user_review_count: 1)
+    @event = create(:event, :with_user_reviews, user_review_count: 1)
     @admin = create(:user, :admin)
     @user_review = @event.user_reviews.first
   end

--- a/spec/features/guest_views_current_events_dashboard_spec.rb
+++ b/spec/features/guest_views_current_events_dashboard_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+feature "Guest views current events dashboard" do
+  scenario "and sees open events" do
+    event = create(:event, :with_reviews, :open)
+
+    visit root_path
+    click_link "Current Events"
+
+    expect(page).to have_event(event)
+    expect_page_to_have_review_summaries_for(event)
+  end
+
+  scenario "and does not see closed events" do
+    event = create(:event, :closed)
+
+    visit root_path
+    click_link "Current Events"
+
+    expect(page).not_to have_event(event)
+  end
+
+  def have_event(event)
+    have_css(".event", text: event.name) &&
+    have_css(".event", text: event.venue)
+  end
+
+  def expect_page_to_have_review_summaries_for(event)
+    expect_page_to_have_media_review_summary_for(event)
+    expect_page_to_have_user_review_summary_for(event)
+  end
+
+  def expect_page_to_have_media_review_summary_for(event)
+    within(".review-score", text: "Critics") do
+      expect(page).to have_text(event.average_media_review_score)
+      expect(page).to have_review_count(event.media_reviews.count)
+    end
+  end
+
+  def expect_page_to_have_user_review_summary_for(event)
+    within(".review-score", text: "Users") do
+      expect(page).to have_text(event.average_user_review_score)
+      expect(page).to have_review_count(event.user_reviews.count)
+    end
+  end
+
+  def have_review_count(count)
+    have_text("#{count} Reviews")
+  end
+end

--- a/spec/features/guest_views_event_spec.rb
+++ b/spec/features/guest_views_event_spec.rb
@@ -13,7 +13,7 @@ feature "Guest views event" do
   end
 
   scenario "and sees media reviews for that event" do
-    event = create(:event_with_media_reviews)
+    event = create(:event, :with_media_reviews)
     num_media_reviews = event.media_reviews.count
     media_review = event.media_reviews.first
 
@@ -37,7 +37,7 @@ feature "Guest views event" do
   end
 
   scenario "and sees user reviews for that event" do
-    event = create(:event_with_user_reviews)
+    event = create(:event, :with_user_reviews)
     num_user_reviews = event.user_reviews.count
     user_review = event.user_reviews.first
 


### PR DESCRIPTION
Additionally, refactor `factories.rb` to make events with user and
media reviews traits of the events factory, instead of sub-factories.
This allows easier creation of events with both types of reviews.

Note: The helper methods in this spec are intended to be reusable across
other dashboard specs, and can be extracted when they are written.
