### PR TITLE
Infer Media Review Source from URL

### DIFF
--- a/app/controllers/admin/media_reviews_controller.rb
+++ b/app/controllers/admin/media_reviews_controller.rb
@@ -63,15 +63,16 @@ class Admin::MediaReviewsController < AdminController
   def media_review_params_with_metadata
     params.
       require(:media_review).
-      permit(:url, :source).
+      permit(:url).
       merge(metadata_params)
   end
 
   def metadata_params
     {
-      headline: metadata.title,
       author: metadata.author,
-      sentiment: metadata.sentiment
+      headline: metadata.title,
+      sentiment: metadata.sentiment,
+      source: metadata.source
     }
   end
 end

--- a/app/models/media_review_metadata_extractor.rb
+++ b/app/models/media_review_metadata_extractor.rb
@@ -1,25 +1,31 @@
 class MediaReviewMetadataExtractor
-  attr_reader :title, :author, :sentiment, :analyzed_text
-
   def initialize(url)
     @url = url
-    @title = title_query_response.titleize
-    @author = author_query_response.titleize
-    @sentiment = sentiments_query_response["docSentiment"]["score"]
-    @analyzed_text = sentiments_query_response["text"]
+  end
+
+  def analyzed_text
+    sentiments_query_response["text"]
+  end
+
+  def author
+    AlchemyAPI::AuthorExtraction.new.search(url: url).titleize
+  end
+
+  def sentiment
+    sentiments_query_response["docSentiment"]["score"]
+  end
+
+  def source
+    UrlSourceExtractor.new(url).source
+  end
+
+  def title
+    AlchemyAPI::TitleExtraction.new.search(url: url).titleize
   end
 
   private
 
   attr_reader :url
-
-  def title_query_response
-    @title_query_response = AlchemyAPI::TitleExtraction.new.search(url: url)
-  end
-
-  def author_query_response
-    @author_query_respose = AlchemyAPI::AuthorExtraction.new.search(url: url)
-  end
 
   def sentiments_query_response
     @sentiments_query_response ||= perform_sentiments_query

--- a/app/models/url_source_extractor.rb
+++ b/app/models/url_source_extractor.rb
@@ -1,0 +1,27 @@
+class UrlSourceExtractor
+  SOURCES = YAML.load_file(Rails.root.join("config", "url_sources.yaml"))
+
+  def initialize(url)
+    @url_domain = host_for(url)
+  end
+
+  def source
+    matching_sources.first || @url_domain
+  end
+
+  private
+
+  def host_for(url)
+    URI.parse(url).host
+  end
+
+  def matching_sources
+    SOURCES.select do |domain, _source|
+      url_domain_ends_with(domain)
+    end.values
+  end
+
+  def url_domain_ends_with(domain)
+    @url_domain =~ /#{domain}\Z/
+  end
+end

--- a/app/views/admin/media_reviews/_media_review_form.html.erb
+++ b/app/views/admin/media_reviews/_media_review_form.html.erb
@@ -4,7 +4,3 @@
   <%= form.label :url, "URL" %>
   <%= form.text_field :url %>
 </div>
-<div>
-  <%= form.label :source %>
-  <%= form.text_field :source %>
-</div>

--- a/app/views/admin/media_reviews/edit.html.erb
+++ b/app/views/admin/media_reviews/edit.html.erb
@@ -6,6 +6,10 @@
   <%= render "media_review_form", form: form %>
 
   <div>
+    <%= form.label :source %>
+    <%= form.text_field :source %>
+  </div>
+  <div>
     <%= form.label :headline %>
     <%= form.text_field :headline %>
   </div>

--- a/config/url_sources.yaml
+++ b/config/url_sources.yaml
@@ -1,0 +1,23 @@
+---
+amny.com: AM New York
+ap.org: Associated Press
+backstage.com: Backstage
+bloomberg.com: Bloomberg
+chicagotribune.com: Chicago Tribune
+ew.com: Entertainment Weekly
+hollywoodreporter.com: Hollywood Reporter
+huffingtonpost.com: Huffington Post
+latimes.com: LA Times
+nbcnewyork.com: NBC New York
+newsday.com: Newsday
+newyorker.com: New Yorker
+ny1.com: NY1
+nymag.com: New York Magazine
+nyti.ms: New York Times
+nytimes.com: New York Times
+timeout.com: Time Out New York
+theatermania.com: Theatermania
+usatoday.com: USA Today
+variety.com: Variety
+vulture.com: New York Magazine
+washingtonpost.com: Washington Post

--- a/spec/features/admin_creates_media_review_spec.rb
+++ b/spec/features/admin_creates_media_review_spec.rb
@@ -32,7 +32,6 @@ feature "Admin creates media review" do
   def create_media_review(media_review)
     click_link "Add a Critic Review"
     fill_in "URL", with: media_review.url
-    fill_in "Source", with: media_review.source
     click_button "Add Critic Review"
   end
 

--- a/spec/models/media_review_metadata_extractor_spec.rb
+++ b/spec/models/media_review_metadata_extractor_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+vcr_options = { cassette_name: "media_review_metadata" }
+
+describe MediaReviewMetadataExtractor, vcr: vcr_options do
+  before do
+    @media_review = build_stubbed(:media_review)
+    @extractor = MediaReviewMetadataExtractor.new(@media_review.url)
+  end
+
+  describe "#title" do
+    it "returns the title for the given url" do
+      expect(@extractor.title).to match(/#{@media_review.headline}/)
+    end
+  end
+
+  describe "#author" do
+    it "returns the author for the given url" do
+      expect(@extractor.author).to match(/#{@media_review.author}/)
+    end
+  end
+
+  describe "#sentiment" do
+    it "returns the numerical sentiment for the given url" do
+      expect(@extractor.sentiment).to match(/#{@media_review.sentiment}/)
+    end
+  end
+
+  describe "#analyzed_text" do
+    it "returns the text that was analyzed for sentiment" do
+      expect(@extractor.analyzed_text).to be_a(String)
+      expect(@extractor.analyzed_text).not_to eq ""
+    end
+  end
+
+  describe "#source" do
+    it "returns the text source for the given url" do
+      expect(@extractor.source).to match(/#{@media_review.source}/)
+    end
+  end
+end

--- a/spec/models/url_source_extractor_spec.rb
+++ b/spec/models/url_source_extractor_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe UrlSourceExtractor do
+  describe "#source" do
+    context "with a known source" do
+      it "returns the text name of the source for a given URL" do
+        extractor = UrlSourceExtractor.new("http://www.nytimes.com")
+        another_extractor = UrlSourceExtractor.new("http://www.newyorker.com")
+
+        expect(extractor.source).to match(/New York Times/)
+        expect(another_extractor.source).to match(/New Yorker/)
+      end
+    end
+
+    context "with an unknown source" do
+      it "returns the host name of the given url without the path" do
+        extractor = UrlSourceExtractor.new("http://unknown.host.name/path/foo")
+
+        expect(extractor.source).to eq("unknown.host.name")
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ require "webmock/rspec"
 VCR.configure do |c|
   c.cassette_library_dir = "spec/fixtures/vcr_cassettes"
   c.hook_into :webmock
+  c.configure_rspec_metadata!
   c.filter_sensitive_data("<ALCHEMY_API_KEY>") do
     ENV["ALCHEMY_API_KEY"]
   end


### PR DESCRIPTION
Admins no longer have to manually type the source when creating a
Media review; the source is inferred based on the URL.

This commit adds a `UrlSourceExtractor` class to determine the source
name from a given URL, and updates the `MediaReviewMetadataExtractor`
class to extract the source in addition to other metadata.

Additionally, this commit adds unit specs for
`MediaReviewMetadataExtractor` and refactors.

https://trello.com/c/80R2da0x
